### PR TITLE
Allow for resolveCallback to be used appropriately

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -32,7 +32,10 @@ class Money extends Number
         $this->step(1 / $this->minorUnit($currency));
 
         $this
-            ->resolveUsing(function ($value) use ($currency) {
+            ->resolveUsing(function ($value) use ($currency, $resolveCallback) {
+                if ($resolveCallback !== null) {
+                    $value = call_user_func_array($resolveCallback, func_get_args());       
+                }
                 return $this->inMinorUnits ? $value / $this->minorUnit($currency) : (float) $value;
             })
             ->fillUsing(function (NovaRequest $request, $model, $attribute, $requestAttribute) use ($currency) {

--- a/src/Money.php
+++ b/src/Money.php
@@ -2,12 +2,12 @@
 
 namespace Vyuldashev\NovaMoneyField;
 
-use Money\Currency;
 use Laravel\Nova\Fields\Number;
-use Money\Currencies\ISOCurrencies;
-use Money\Currencies\BitcoinCurrencies;
-use Money\Currencies\AggregateCurrencies;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Money\Currencies\AggregateCurrencies;
+use Money\Currencies\BitcoinCurrencies;
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
 
 class Money extends Number
 {
@@ -34,8 +34,9 @@ class Money extends Number
         $this
             ->resolveUsing(function ($value) use ($currency, $resolveCallback) {
                 if ($resolveCallback !== null) {
-                    $value = call_user_func_array($resolveCallback, func_get_args());       
+                    $value = call_user_func_array($resolveCallback, func_get_args());
                 }
+
                 return $this->inMinorUnits ? $value / $this->minorUnit($currency) : (float) $value;
             })
             ->fillUsing(function (NovaRequest $request, $model, $attribute, $requestAttribute) use ($currency) {


### PR DESCRIPTION
This adds in the ability to use the custom Resolve on creation to set default and the such.

Since Nova Fields can only ever have 1 resolveUsing callback, the Money Field's internal resolveUsing overwrites any set in the resource.

This now allows for check in the replacement callback to see if we have one, and to call that directly.